### PR TITLE
PBI-23: fix view lesson material

### DIFF
--- a/src/Controllers/TopicController.php
+++ b/src/Controllers/TopicController.php
@@ -4,7 +4,6 @@ namespace Uasoft\Badaso\Module\LMSModule\Controllers;
 
 use Exception;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Uasoft\Badaso\Controllers\Controller;
 use Uasoft\Badaso\Helpers\ApiResponse;

--- a/tests/Feature/TopicApiTest.php
+++ b/tests/Feature/TopicApiTest.php
@@ -198,6 +198,39 @@ class TopicApiTest extends TestCase
         $this->assertArrayHasKey('topicId', $lessonMaterialData);
     }
 
+    public function testBrowseTopicGivenValidUserExpectRespondsWithLessonMaterialsThatHaveNoTopic()
+    {
+        $user = User::factory()->create();
+        $user->rawPassword = 'password';
+
+        $course = Course::factory()
+            ->hasAttached($user, ['role' => CourseUserRole::STUDENT])
+            ->create();
+
+        LessonMaterial::factory()
+            ->for($course)
+            ->create();
+
+        $url = route('badaso.topic.browse', ['course_id' => $course->id]);
+        $response = AuthHelper::asUser($this, $user)->json('GET', $url);
+
+        $topicsData = $response->json('data');
+        $nullTopic = $topicsData[0];
+        $lessonMaterialsData = $nullTopic['lessonMaterials'];
+        $lessonMaterialData = $lessonMaterialsData[0];
+
+        $response->assertStatus(200);
+
+        $this->assertNull($nullTopic['id']);
+        $this->assertNull($nullTopic['title']);
+
+        $this->assertCount(1, $lessonMaterialsData);
+        $this->assertArrayHasKey('id', $lessonMaterialData);
+        $this->assertArrayHasKey('title', $lessonMaterialData);
+        $this->assertArrayHasKey('createdAt', $lessonMaterialData);
+        $this->assertArrayHasKey('topicId', $lessonMaterialData);
+    }
+
     public function testEditTopicWithoutLogin()
     {
         $url = route('badaso.topic.edit', ['id' => 1]);


### PR DESCRIPTION
### Changes
- return lesson materials with no topic on browse topic

### Preview
- If there's lesson material with topic = null, then the response will be pretty much like this
```json
{
    "message": "Request was successful",
    "errors": null,
    "data": [
        {
            "id": null,
            "title": null,
            "courseId": "1",
            "lessonMaterials": [
                {
                    "id": 1,
                    "title": "quam excepturi qui",
                    "createdAt": "2022-04-14T10:24:22.000000Z",
                    "topicId": null
                }
            ]
        },
        {
            "id": 3,
            "title": "Pre-emptive disintermediate customer loyalty",
            "courseId": 1,
            "createdBy": 1,
            "lessonMaterials": [
                {
                    "id": 10,
                    "title": "new - eco-centric",
                    "createdAt": "2022-04-19T03:23:24.000000Z",
                    "topicId": 3
                }
             ]
        }
    ]
}
```

- but if there's no lesson material with topic == null, then the topic null object won't be returned, pretty much like this
```json
{
    "message": "Request was successful",
    "errors": null,
    "data": [
        {
            "id": 3,
            "title": "Pre-emptive disintermediate customer loyalty",
            "courseId": 1,
            "createdBy": 1,
            "lessonMaterials": [
                {
                    "id": 10,
                    "title": "new - eco-centric",
                    "createdAt": "2022-04-19T03:23:24.000000Z",
                    "topicId": 3
                }
             ]
        }
    ]
}
```